### PR TITLE
Using PolyLine and drawing less points.

### DIFF
--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -321,15 +321,22 @@ void renderBankGrid(const char *name, float height, int gridWidth, float *gridX,
 
 		// Draw lines
 		ImGui::PushClipRect(cellBox.Min, cellBox.Max, true);
-		int divisor = 8; // only draw an eigth of the points plus the last one
+		// We only draw an eigth of the points plus the last one
+		int divisor = 4;
 		std::vector<ImVec2> points;
 		points.reserve(1 + WAVE_LEN/divisor);
-		for (int i = 0; i < 1 + WAVE_LEN; i += divisor) {
+		for (int i = 0; i < WAVE_LEN; i += divisor) {
 			float value = currentBank.waves[j].postSamples[i];
 			float margin = 3.0;
 			ImVec2 pos = ImVec2(rescalef(i, 0, WAVE_LEN - 1, cellBox.Min.x, cellBox.Max.x), rescalef(value, 1.0, -1.0, cellBox.Min.y + margin, cellBox.Max.y - margin));
 			points.emplace_back(pos);
 		}
+
+		// last point
+		float value = currentBank.waves[j].postSamples[WAVE_LEN - 1];
+		float margin = 3.0;
+		ImVec2 pos = ImVec2(rescalef(WAVE_LEN - 1, 0, WAVE_LEN - 1, cellBox.Min.x, cellBox.Max.x), rescalef(value, 1.0, -1.0, cellBox.Min.y + margin, cellBox.Max.y - margin));
+		points.emplace_back(pos);
 		window->DrawList->AddPolyline(points.data(), 1 + WAVE_LEN/divisor, ImGui::GetColorU32(ImGuiCol_PlotLines), false, 1.0, false);
 
 

--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -321,15 +321,17 @@ void renderBankGrid(const char *name, float height, int gridWidth, float *gridX,
 
 		// Draw lines
 		ImGui::PushClipRect(cellBox.Min, cellBox.Max, true);
-		ImVec2 lastPos;
-		for (int i = 0; i < WAVE_LEN; i++) {
+		int divisor = 8; // only draw an eigth of the points plus the last one
+		std::vector<ImVec2> points;
+		points.reserve(1 + WAVE_LEN/divisor);
+		for (int i = 0; i < 1 + WAVE_LEN; i += divisor) {
 			float value = currentBank.waves[j].postSamples[i];
 			float margin = 3.0;
 			ImVec2 pos = ImVec2(rescalef(i, 0, WAVE_LEN - 1, cellBox.Min.x, cellBox.Max.x), rescalef(value, 1.0, -1.0, cellBox.Min.y + margin, cellBox.Max.y - margin));
-			if (i > 0)
-				window->DrawList->AddLine(lastPos, pos, ImGui::GetColorU32(ImGuiCol_PlotLines));
-			lastPos = pos;
+			points.emplace_back(pos);
 		}
+		window->DrawList->AddPolyline(points.data(), 1 + WAVE_LEN/divisor, ImGui::GetColorU32(ImGuiCol_PlotLines), false, 1.0, false);
+
 
 		// Draw cell label
 		char label[64];

--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -321,7 +321,7 @@ void renderBankGrid(const char *name, float height, int gridWidth, float *gridX,
 
 		// Draw lines
 		ImGui::PushClipRect(cellBox.Min, cellBox.Max, true);
-		// We only draw an eigth of the points plus the last one
+		// We only draw a fourth of the points plus the last one
 		int divisor = 4;
 		std::vector<ImVec2> points;
 		points.reserve(1 + WAVE_LEN/divisor);


### PR DESCRIPTION
WaveEdit used 50% of my MacBook Pro 2015 CPU when completely idle.

The culprit was `renderBankGrid` which needs to draw so many lines (just commenting it
dropped usage to 13%).

Drawing only a fourth of the points and using AddPolyLine (which draws them all together),
I managed to get the CPU usage down to 20%.

(I know "CPU usage" is a weak measure, I did check v-sync-less framerate too)

This of course means the preview waves lose some resolution, so no hard feelings if you don't wanna merge this 😁

(I guess the "correct" way to do this is some kind of interpolation)