### PR TITLE
Include path to XQuartz X11 headers on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ else ifeq ($(ARCH),mac)
 	# Mac
 	FLAGS += -DARCH_MAC \
 		-mmacosx-version-min=10.7
-	CXXFLAGS += -stdlib=libc++
+	CXXFLAGS += -stdlib=libc++ -I/opt/X11/include
 	LDFLAGS += -mmacosx-version-min=10.7 \
 		-stdlib=libc++ -lpthread \
 		-framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo \


### PR DESCRIPTION
[XQuartz](https://www.xquartz.org) installs to /opt/X11. Include headers from there so `make` runs successfully.

I don't know if there's a way to set up this link globally, but this is what it took to get it working for me. I'm using OS X 10.10.5 and I installed XQuartz using `brew cask install xquartz`.

If anyone else tries to build this on Mac, this config addition should save them a step at least.