### PR TITLE
Add Trim control to beginning of effect path.

### DIFF
--- a/src/WaveEdit.hpp
+++ b/src/WaveEdit.hpp
@@ -123,6 +123,7 @@ unsigned char *base64_decode(const unsigned char *src, size_t len, size_t *out_l
 #define WAVE_LEN 256
 
 enum EffectID {
+	TRIM,
 	PRE_GAIN,
 	PHASE_SHIFT,
 	HARMONIC_SHIFT,

--- a/src/wave.cpp
+++ b/src/wave.cpp
@@ -8,6 +8,7 @@ bool clipboardActive = false;
 
 
 const char *effectNames[EFFECTS_LEN] {
+	"Trim",
 	"Pre-Gain",
 	"Phase Shift",
 	"Harmonic Shift",
@@ -30,6 +31,14 @@ void Wave::clear() {
 void Wave::updatePost() {
 	float out[WAVE_LEN];
 	memcpy(out, samples, sizeof(float) * WAVE_LEN);
+
+	// Trim
+	if (effects[TRIM]) {
+		float gain = powf(20.0, effects[TRIM]);
+		for (int i = 0; i < WAVE_LEN; i++) {
+			out[i] *= (1.0 / gain);
+		}
+	}
 
 	// Pre-gain
 	if (effects[PRE_GAIN]) {
@@ -264,7 +273,8 @@ void Wave::bakeEffects() {
 }
 
 void Wave::randomizeEffects() {
-	for (int i = 0; i < EFFECTS_LEN; i++) {
+	// Start at 1 so we don't randomize Trim and Gain together
+	for (int i = 1; i < EFFECTS_LEN; i++) {
 		effects[i] = randf() > 0.5 ? powf(randf(), 2) : 0.0;
 	}
 	updatePost();


### PR DESCRIPTION
This lets the user reduce the waveform volume, and control the amount of clipping that occurs when drawing harmonics.

---

I wasn't sure how to make the pre-gain a bipolar control. Maybe that would be preferable. But I got this working in a few minutes, it maintains the 0-to-1 slider interface, and I'm happy!