### PR TITLE
Fix include paths and libs for Linux compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,14 @@ SOURCES = \
 include Makefile-arch.inc
 ifeq ($(ARCH),lin)
 	# Linux
-	FLAGS += -DARCH_LIN $(shell pkg-config --cflags gtk+-2.0)
+	FLAGS += -DARCH_LIN \
+		$(shell pkg-config --cflags gtk+-2.0) \
+		$(shell pkg-config --cflags sdl2)
 	LDFLAGS += -static-libstdc++ -static-libgcc \
 		-lGL -lpthread \
-		-Ldep/lib -lSDL2 -lsamplerate -lsndfile -ljansson -lcurl \
-		-lgtk-x11-2.0 -lgobject-2.0
+		-Ldep/lib -lsamplerate -lsndfile -ljansson -lcurl \
+		$(shell pkg-config --libs sdl2) \
+		$(shell pkg-config --libs gtk+-2.0)
 	SOURCES += ext/osdialog/osdialog_gtk2.c
 else ifeq ($(ARCH),mac)
 	# Mac


### PR DESCRIPTION
This also allows to build WaveEdit with the system installed `jansson`, `samplerate`, `sndfile` and `SDL2`.